### PR TITLE
The pytorch module is actually named `torch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Following methods are currently or will be implemented:
 
 Make sure the following libraries are installed or install them using 
 ```sh
-pip install pytorch torchvision tqdm matplotlib transformers seaborn scikit-learn networkx
+pip install torch torchvision tqdm matplotlib transformers seaborn scikit-learn networkx
 ```
 
 ### Installation


### PR DESCRIPTION
When I do `pip install pytorch` I get an error

    Exception: You tried to install "pytorch". The package named for PyTorch is "torch"

When I do `pip install torch`, it installs and I can run the experiments.