### PR TITLE
Fix: ModuleNotFoundError: No module named 'toumei'

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ pip install pytorch torchvision tqdm matplotlib transformers seaborn scikit-lear
 2. Run the experiments
    ```sh
    cd toumei/experiments
-   python <experiment>.py
+   PYTHONPATH=.. python <experiment>.py
    ```
 3. Move the library to your project
    ```sh


### PR DESCRIPTION
When I run experiments following the instructions, I get this error. e.g.

```
$ python modularity.py
Traceback (most recent call last):
  File "/home/phil/prog/toumei/experiments/modularity.py", line 3, in <module>
    from toumei.misc import MLPGraph, CNNGraph
ModuleNotFoundError: No module named 'toumei'
```

The problem is that `sys.path` doesn't include the root of the repository, which includes the toumei/ folder. There's a few ways to avoid that. Putting `PYTHONPATH` in the environment alters `sys.path`, i.e.

```
$ PYTHONPATH=.. python modularity.py
# This works
```

Another way is `ln -s ../toumei toumei` from inside the `experiments` folder. That folder is included in sys.path when running experiments (because it's the folder the script is found in, regardless of where it's run from), so the link means the module is now visible. There may be nicer ways too.

This may well differ between environments and python versions? I'm using python 3.10.3 on arch linux.