### PR TITLE
Graphs from overparameterized broadness script

### DIFF
--- a/experiments/research/overparameterized-model/overparameterized_broadness.py
+++ b/experiments/research/overparameterized-model/overparameterized_broadness.py
@@ -1,3 +1,4 @@
+import argparse
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -60,7 +61,14 @@ def train(net, criterion, optimizer):
             last_loss = val
 
 def main():
-    torch.manual_seed(0)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--seed', type=int, default=0)
+
+    args = parser.parse_args()
+
+    # Would "generate and print random seed" be useful instead of defaulting to
+    # 0?
+    torch.manual_seed(args.seed)
 
     net = Net_9()
     criterion = nn.MSELoss()


### PR DESCRIPTION
I finally got around to adding the graphs I mentioned in #15. Here's what they look like for seeds 0 through 4:

![image](https://user-images.githubusercontent.com/57271/210139931-8925741d-5a21-4c3a-b316-7ba50bd51d58.png)
![image](https://user-images.githubusercontent.com/57271/210139940-e0b19952-3a3c-4cf5-a55b-8cbb47c38fc8.png)
![image](https://user-images.githubusercontent.com/57271/210139944-52a12c5e-d478-42bb-b523-fe85ca0d142d.png)
![image](https://user-images.githubusercontent.com/57271/210139947-b64f46f5-ecf1-4b44-80e2-28ed91eef731.png)
![image](https://user-images.githubusercontent.com/57271/210139950-685c7506-13f5-4139-a541-38d61eef0201.png)

So 0, 3 and 4 look very similar, but 1 and 2 are different.

My understanding is that this basically answers the question this was looking at? That is, my understanding is that the point of this was to answer "if we train an overparameterized model, do we reliably get the same result" and this says that no we don't. But I'm not confident I understand well.